### PR TITLE
Updated ConfirmDetailsAreValidForModulusCheck.cs

### DIFF
--- a/ConfirmDetailsAreValidForModulusCheck.cs
+++ b/ConfirmDetailsAreValidForModulusCheck.cs
@@ -1,0 +1,39 @@
+using ModulusChecking.Models;
+
+namespace ModulusChecking.Steps
+{
+    /// <summary>
+    /// The first step is to test if the given sort code can be found in the Modulus Weight Mappings.
+    /// If not default is to presume valid
+    /// </summary>
+    internal class ConfirmDetailsAreValidForModulusCheck
+    {
+        private readonly FirstModulusCalculatorStep _firstModulusCalculatorStep;
+
+        public ConfirmDetailsAreValidForModulusCheck() { _firstModulusCalculatorStep = new FirstModulusCalculatorStep(); }
+
+        public ConfirmDetailsAreValidForModulusCheck(FirstModulusCalculatorStep nextStep)
+        { _firstModulusCalculatorStep = nextStep; }
+
+
+
+        /// <summary>
+        /// If there are no SortCode Modulus Weight Mappings available then the BankAccountDetails validate as 'isNotFoundValid'
+        /// Otherwise move onto the first modulus calculation step
+        /// </summary>
+        /// <param name="bankAccountDetails"></param>
+        /// <param name="isNotFoundValid">return value when no SortCode Modulus Weight Mappings are available</param>
+        /// <returns></returns>
+        public bool Process(BankAccountDetails bankAccountDetails, bool isNotFoundValid = true)
+        {
+            var isValidForModulusCheck = bankAccountDetails.IsValidForModulusCheck();
+            var isUncheckableForeignAccount = bankAccountDetails.IsUncheckableForeignAccount();
+            
+            if (!isValidForModulusCheck || isUncheckableForeignAccount)
+                return isNotFoundValid;
+
+            var result = _firstModulusCalculatorStep.Process(bankAccountDetails);
+            return result;
+        }
+    }
+}

--- a/ModulusChecker.cs
+++ b/ModulusChecker.cs
@@ -1,0 +1,30 @@
+﻿using ModulusChecking.Loaders;
+using ModulusChecking.Models;
+using ModulusChecking.Steps;
+
+namespace ModulusChecking
+{
+    public class ModulusChecker
+    {
+        private readonly IModulusWeightTable _weightTable;
+
+        public ModulusChecker()
+        {
+            _weightTable = ModulusWeightTable.GetInstance;
+        }
+
+        /// <summary>
+        /// Method to check the sort code against bank account, optionally specifiy what happens when no sort code weightings are found
+        /// </summary>
+        /// <param name="sortCode"></param>
+        /// <param name="accountNumber"></param>
+        /// <param name="isNotFoundValid"></param>
+        /// <returns></returns>
+        public bool CheckBankAccount(string sortCode, string accountNumber, bool isNotFoundValid = true)
+        {
+            var bankAccountDetails = new BankAccountDetails(sortCode, accountNumber);
+            bankAccountDetails.WeightMappings = _weightTable.GetRuleMappings(bankAccountDetails.SortCode);
+            return new ConfirmDetailsAreValidForModulusCheck().Process(bankAccountDetails, isNotFoundValid);
+        }
+    }
+}


### PR DESCRIPTION
Added the ability to control the return Boolean when there are no SortCode Modulus Weight Mappings available. This will default to 'isNotFoundValid = true' so there are no breaking changes.